### PR TITLE
77 duplicate label attributes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,7 @@ release = "0.0.1"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosectionlabel"]
+extensions = ["sphinx.ext.autodoc", "myst_parser"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,3 +1,5 @@
+.. _contributing:
+
 Contributing to Spur
 ====================
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,7 +22,7 @@ The documentation here is designed both as a user manual and as a technical
 documentation source for developers wishing to adapt or extend the software or
 build their own plugins.
 
-If you are interested in contributing to the project, please consult our :ref:`contribution guide<Contributing to Spur>`.
+If you are interested in contributing to the project, please consult our :ref:`contribution guide<contributing>`.
 
 
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -3,9 +3,9 @@ Getting Started
 
 Creating a simulation requires a few key sources of data:
 
-* A list of :ref:`components<Component>` that form the simulated network,
-* A train or set of trains which traverses the network (see :ref:`Train` documentation for details), and
-* A set of :ref:`tours<Tour>` and :ref:`routes<Route>` defined.
+* A list of :ref:`components<ref_component>` that form the simulated network,
+* A train or set of trains which traverses the network (see :ref:`Train<ref_train>` documentation for details), and
+* A set of :ref:`tours<ref_tour>` and :ref:`routes<ref_route>` defined.
 
 These data can be manually added in code, or defined in a JSON format.
 

--- a/docs/source/reference/core.rst
+++ b/docs/source/reference/core.rst
@@ -1,6 +1,8 @@
 Core Contents
 =============
 
+.. _ref_component:
+
 Component
 ##########
 .. automodule:: spur.core.component
@@ -21,15 +23,21 @@ Model
 .. automodule:: spur.core.model
    :members:
 
+.. _ref_route:
+
 Route
 #####
 .. automodule:: spur.core.route
    :members:
 
+.. _ref_tour:
+
 Tour
 ####
 .. automodule:: spur.core.tour
    :members:
+
+.. _ref_train:
 
 Train
 #####

--- a/docs/source/reference/core.rst
+++ b/docs/source/reference/core.rst
@@ -8,7 +8,7 @@ Component
 
 Exception
 ##########
-.. automodule:: spur.core.exceptions
+.. automodule:: spur.core.exception
    :members:
 
 Jitter

--- a/docs/source/reference/gui.rst
+++ b/docs/source/reference/gui.rst
@@ -1,4 +1,0 @@
-GUI Contents
-============
-
-Coming soon...

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -5,4 +5,3 @@ Module Contents
     :glob:
     
     core
-    gui


### PR DESCRIPTION
Fix duplicate label attributes configurations, and fix some linking issues in the code.

This is all documentation-level changes to get Sphinx working better.